### PR TITLE
Added support for options.istanbul.excludes to exclude glob-matched paths from coverage reports

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-js-test",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "dependencies": {
     "body-parser": {
       "version": "1.12.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-js-test",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "description": "Grunt task for running client-side, mocha-based unit tests in PhantomJS with code coverage reports",
   "keywords": [
     "grunt",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "jade": "1.x",
     "lodash": "^2.4.1",
     "moment": "^2.8.1",
+    "minimatch": "^2.0.4",
     "phantomjs": "1.9.13",
     "request": "^2.34.0"
   },

--- a/tasks/js-test.js
+++ b/tasks/js-test.js
@@ -325,7 +325,9 @@ module.exports = function (grunt) {
         try {
           var exec = require('child_process').exec;
           exec('start "" "http://' + options.hostname + ':' + options.port + '"');
-        } catch (ex) {}
+        } catch (ex) {
+          // empty
+        }
       }
 
       grunt.task.run('js-test-server-keepalive');

--- a/tasks/lib/coverage-reporters/istanbul.js
+++ b/tasks/lib/coverage-reporters/istanbul.js
@@ -4,10 +4,15 @@ var fs = require('fs');
 var path = require('path');
 var express = require('express');
 var istanbul = require('istanbul');
+var Minimatch = require('minimatch').Minimatch;
 
 module.exports = function (grunt, options, reportDirectory) {
   var instrumenter = new istanbul.Instrumenter();
   var collector = new istanbul.Collector();
+  var excludeMatch;
+  if (options.istanbul && options.istanbul.excludes) {
+    excludeMatch = new Minimatch(options.istanbul.excludes);
+  }
 
   return {
     start: function () {
@@ -16,8 +21,8 @@ module.exports = function (grunt, options, reportDirectory) {
       app.use(options.baseUri, function (req, res) {
         var file = path.join(options.root, req.path);
 
-        // if we're not requesting a JS file, do not instrunment it
-        if (path.extname(file) != '.js') {
+        // if we're not requesting a JS file, do not instrument it
+        if ((path.extname(file) != '.js') || (excludeMatch && excludeMatch.match(file))) {
           //Allow cross-origin resource requests during testing (e.g. handlebars templates)
           res.header('Access-Control-Allow-Origin', '*');
           res.header('Access-Control-Allow-Headers', 'X-Requested-With');

--- a/tasks/lib/server.js
+++ b/tasks/lib/server.js
@@ -172,6 +172,7 @@ module.exports = function (grunt, options) {
       injectHTML += fs.readFileSync(test.abs.replace(/\.js$/, '.inject.html'));
     } catch (ex) {
       // no .inject.html exists, most likely, so move on
+      // empty
     }
 
     // if the test has an inject URL, request it and inject it


### PR DESCRIPTION
With this fix, you can now exclude things like thirdparty libraries from code-coverage reports generated by istanbul.
A similar fix should be made for JSCover.
