### PR TITLE
Now allow the user to specify the output format of the coverage test

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,8 +44,8 @@
     "istanbul": "^0.3.0",
     "jade": "1.x",
     "lodash": "^2.4.1",
-    "moment": "^2.8.1",
     "minimatch": "^2.0.4",
+    "moment": "^2.8.1",
     "phantomjs": "1.9.13",
     "request": "^2.34.0"
   },
@@ -53,6 +53,7 @@
     "grunt": "~0.4"
   },
   "devDependencies": {
-    "grunt-eslint": ">=0.6.0"
+    "grunt-eslint": ">=0.6.0",
+    "minimatch": "^2.0.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -44,8 +44,8 @@
     "istanbul": "^0.3.0",
     "jade": "1.x",
     "lodash": "^2.4.1",
-    "minimatch": "^2.0.4",
     "moment": "^2.8.1",
+    "minimatch": "^2.0.4",
     "phantomjs": "1.9.13",
     "request": "^2.34.0"
   },
@@ -53,7 +53,6 @@
     "grunt": "~0.4"
   },
   "devDependencies": {
-    "grunt-eslint": ">=0.6.0",
-    "minimatch": "^2.0.4"
+    "grunt-eslint": ">=0.6.0"
   }
 }

--- a/tasks/js-test.js
+++ b/tasks/js-test.js
@@ -285,7 +285,7 @@ module.exports = function (grunt) {
     if (options.coverage) {
       grunt.log.writeln('Generating coverage report.');
 
-      expressApp.saveCoverageReport(function (err) {
+      expressApp.saveCoverageReport(options.coverageFormat, function (err) {
         if (err) {
           grunt.log.error('Failed to generate coverage report.');
         }

--- a/tasks/lib/coverage-reporters/istanbul.js
+++ b/tasks/lib/coverage-reporters/istanbul.js
@@ -69,10 +69,12 @@ module.exports = function (grunt, options, reportDirectory) {
       cb(null);
     },
 
-    aggregate: function (cb) {
+    aggregate: function (format, cb) {
       var reporter = new istanbul.Reporter(null, reportDirectory);
 
-      reporter.add('html');
+      // Default to html if no format provided as this was the prior default
+      format = format || 'html';
+      reporter.add(format);
 
       reporter.write(collector, true, function () {
         grunt.verbose.writeln('Generated coverage report to: ' + reportDirectory);

--- a/tasks/lib/coverage-reporters/jscover.js
+++ b/tasks/lib/coverage-reporters/jscover.js
@@ -7,9 +7,12 @@ var request = require('request');
 var _ = require('lodash');
 
 module.exports = function (grunt, options, reportDirectory) {
-  var startCoverageServer = function () {
+  var startCoverageServer = function (format) {
     // start the jscover proxy server
-    var cmd = 'java -jar "' + path.join(__dirname, 'jscover/JSCover-all.jar') + '" -ws --proxy --port=3128';
+    var cmd = 'java -jar "' + path.join(__dirname, 'jscover/jscover-all.jar') + '" -ws --proxy --port=3128';
+    if (format) {
+      cmd += ' --format=' + format;
+    }
     var exec = require('child_process').exec;
 
     grunt.log.ok('JSCover proxy server started.');
@@ -50,7 +53,7 @@ module.exports = function (grunt, options, reportDirectory) {
       cb(null);
     },
 
-    aggregate: function (cb) {
+    aggregate: function (format, cb) {
       fs.writeFile(path.join(reportDirectory, 'jscover.json'), JSON.stringify(collector), cb);
     }
   };

--- a/tasks/lib/server.js
+++ b/tasks/lib/server.js
@@ -47,9 +47,9 @@ module.exports = function (grunt, options) {
     } catch (ex) {
       options.coverageTool = null;
       options.coverage = false;
-      grunt.log.error('Unsupported coverage reporter, disabling coverage.');
+      grunt.log.error('Unsupported coverage reporter, disabling coverage.', ex);
     } finally {
-      app.coverageServer = coverageTool.start();
+      app.coverageServer = coverageTool.start(options.coverageFormat);
     }
   }
 
@@ -82,8 +82,8 @@ module.exports = function (grunt, options) {
     });
   });
 
-  app.saveCoverageReport = function (cb) {
-    coverageTool.aggregate(function (err) {
+  app.saveCoverageReport = function (format, cb) {
+    coverageTool.aggregate(format, function (err) {
       cb(err);
     });
   };


### PR DESCRIPTION
The impetus behind this change is that currently this library will only spit out the coverage report in html format. 

In order to work with tools like Coveralls, it needs the report in a machine-readable format (lcov).

This pull request still keeps the default at html for istanbul and whatever the default is for jscover when none are specified but also now allows the developer to optionally configure a specific format in the options in grunt for either reporter.

Sample grunt config for `lcov` rather than `html` coverage report below:

```js
options: {
    coverage: true,
    coverageFormat: 'lcov'
}
```