### PR TITLE
Fix timeout issue running coverage on empty test files.

### DIFF
--- a/examples/simple/test/empty.unittests.js
+++ b/examples/simple/test/empty.unittests.js
@@ -1,0 +1,1 @@
+/* this file intentionally empty */

--- a/views/deps/shared.js
+++ b/views/deps/shared.js
@@ -46,7 +46,7 @@
       runner.on('end', function () {
         // save coverage data to server, on complete, let phantom know the tests are over
         saveCoverageDataToServer(function () {
-          createGruntListener('mocha.end')();
+          createGruntListener('end')();
         });
       });
     } else {
@@ -67,7 +67,7 @@
           data.slow = test.slow;
         }
 
-        if (ev == "end") {
+        if (ev == "suite end") {
           data.stats = this.stats;
         }
 


### PR DESCRIPTION
After upgrading from 1.5.7 to 1.5.9 we started getting timeout errors. Upon investigation we found that this occurred when (a) we used the --coverage option and (b) we were running tests on a test file that didn't created any tests (created as a stub). 

This pull request fixes the issue and also adds an empty file to an example project for testing.