### PR TITLE
Allow passing in options to phantomJS

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,11 +249,13 @@ Default: `8983`
 
 Port used for proxy web server that instruments your JavaScript files for code coverage reporting. Should never have to change this unless something else uses this port.
 
-#### mocha
+#### phantomOptions
 Type: `Object`
-Default: `{}`
+Default: `phantomOptions: {
+            timeout: 20000
+          }`
 
-Object of options to pass to the [grunt-mocha](https://github.com/kmiyashiro/grunt-mocha/) task. Hopefully you never need to override anything here.
+Object of options to pass to [PhantomJS](http://phantomjs.org/api/command-line.html)
 
 #### reporter
 Type: `String`

--- a/tasks/js-test.js
+++ b/tasks/js-test.js
@@ -62,10 +62,14 @@ module.exports = function (grunt) {
     serverTimeout: 1000,            // timeout for http connections to servers
 
     // unit testing service options
-    timeout: 20000,                 // grunt-mocha overrides
     reporter: 'Spec',               // mocha reporter to use
     includeChai: true,
     includeSinon: true,
+
+    // phantom js options
+    phantomOptions: {
+      timeout: 20000
+    },
 
     // coverage reporting options
     coverage: false,                // should we generate coverage reports (slows down tests)
@@ -264,10 +268,9 @@ module.exports = function (grunt) {
           // Explicitly set a killTimeout, because grunt-lib-phantomjs is broken currently
           killTimeout: 5000,
           // Pass the options needed to PhantomJS child process
-          options: {
-            timeout: options.timeout,
+          options: _.extend({}, options.phantomOptions, {
             phantomScript: path.join(__dirname, 'lib', 'phantomjs-main.js')
-          },
+          }),
           // Do stuff when done.
           done: function(err) {
             var stats = runner.stats;


### PR DESCRIPTION
There was no way to pass options into phantomJS and the documentation was old and referencing grunt-mocha which is not used.