### PR TITLE
Support relative & absolute path for "--file="

### DIFF
--- a/tasks/js-test.js
+++ b/tasks/js-test.js
@@ -173,9 +173,12 @@ module.exports = function (grunt) {
         grunt.verbose.writeln('  --file filter:', file);
 
         tests = tests.filter(function (test) {
-          var match = normalize(test.file);
-          var pass = file == match;
-          grunt.verbose.writeln('    ', match, '=', pass ? 'true' : 'false');
+          var currentPath = normalize(process.cwd());
+          var absPathToTest = normalize(test.abs);
+          var relativePathToTest = absPathToTest.replace(currentPath, "");
+          var pass = file == relativePathToTest || file == absPathToTest;
+          grunt.verbose.writeln('    ', absPathToTest, '=', file == relativePathToTest ? 'true' : 'false');
+          grunt.verbose.writeln('    ', relativePathToTest, '=', file == absPathToTest ? 'true' : 'false');
           return pass;
         });
 


### PR DESCRIPTION
Previously, when using the `--file=` flag to run a specific test, the path for each test at `test.file` was a static-path starting at `Areas/**/*unittests.js`..Meaning to achieve a match, you always had to provide a path starting at `Areas`, like `Areas\Studio\Tests\Commands\ChangeDesign.unittests.js`.

This change causes the `--flag=` to look for unit test matches based on absolute pathing and relative pathing from the origin of grunt js-test.

